### PR TITLE
gen.py:Add support to conf AppToDIFMaps

### DIFF
--- a/gen.conf
+++ b/gen.conf
@@ -17,3 +17,6 @@ dif n1 c 400
 
 # Security-manager component for dif n1 will use passwd policy set
 policy n1 security-manager passwd
+
+#appmap n1 rina.apps.echotime.server 1
+#appmap n1 rina.apps.echotime.client 1


### PR DESCRIPTION
This commit adds a new declaration "app" to specify the mapping between
applications and difs. The syntax is:

app <app_name> <app_instance> <dif_name>

If no app configuration is added to the configuration file gen.py will fall into
legacy mode where applications in gen_templates.py are mapped to the last
declared top level dif.
