### PR TITLE
gen.py/gen_templates.py: Add policy parms

### DIFF
--- a/gen.py
+++ b/gen.py
@@ -254,16 +254,21 @@ while 1:
 
         continue
 
-    m = re.match(r'\s*policy\s+(\w+)\s+([*\w.-]+)\s+([\w-]+)', line)
+    m = re.match(r'\s*policy\s+(\w+)\s+([*\w.-]+)\s+([\w-]+$)', line)
+    if not m:
+        m = re.match(r'\s*policy\s+(\w+)\s+([*\w.-]+)\s+([\w-]+)\s+([\w=\s]*)$', line)
     if m:
         dif = m.group(1)
         path = m.group(2)
         ps = m.group(3)
+        parms = list()
+        if len(m.groups()) > 3:
+            parms = m.group(4).split(' ')
 
         if dif not in dif_policies:
             dif_policies[dif] = []
 
-        dif_policies[dif].append({'path': path, 'ps': ps})
+        dif_policies[dif].append({'path': path, 'ps': ps, 'parms' : parms})
         if path not in gen_templates.policy_translator:
             print('Unknown component path "%s"' % path)
             quit(1)
@@ -780,7 +785,7 @@ for dif in dif_ordering:
                                 })
 
     for policy in dif_policies[dif]:
-        gen_templates.translate_policy(difconf, policy['path'], policy['ps'])
+        gen_templates.translate_policy(difconf, policy['path'], policy['ps'], policy['parms'])
 
 
 # Dump the DIF Allocator map

--- a/gen_templates.py
+++ b/gen_templates.py
@@ -227,29 +227,38 @@ normal_dif_base =  {
     }
 }
 
-def ps_set(d, k, v):
+def ps_set(d, k, v, parms):
     d[k]["name"] = v
+    if len(parms) > 0:
+        d[k]["parameters"] = [ { 'name': p.split('=')[0], 'value': p.split('=')[1]} for p in parms ]
+
+def dtp_ps_set(d, v, parms):
+    for i in range(len(d["qosCubes"])):
+        ps_set(d["qosCubes"][i]["efcpPolicies"], "dtpPolicySet", v, parms)
+
+def dtcp_ps_set(d, v, parms):
+    for i in range(len(d["qosCubes"])):
+        ps_set(d["qosCubes"][i]["efcpPolicies"]["dtcpConfiguration"], "dtcpPolicySet", v, parms)
 
 policy_translator = {
-    'rmt.pff': lambda d, v: ps_set(d["rmtConfiguration"]["pffConfiguration"], "policySet", v),
-    'rmt': lambda d, v: ps_set(d["rmtConfiguration"], "policySet", v),
-    'enrollment-task': lambda d, v: ps_set(d["enrollmentTaskConfiguration"], "policySet", v),
-    'flow-allocator': lambda d, v: ps_set(d["flowAllocatorConfiguration"], "policySet", v),
-    'namespace-manager': lambda d, v: ps_set(d["namespaceManagerConfiguration"], "policySet", v),
-    'security-manager': lambda d, v: ps_set(d["securityManagerConfiguration"], "policySet", v),
-    'routing': lambda d, v: ps_set(d["routingConfiguration"], "policySet", v),
-    'resource-allocator.pduftg': lambda d, v: ps_set(d["resourceAllocatorConfiguration"], "policySet", v),
+    'rmt.pff': lambda d, v, p: ps_set(d["rmtConfiguration"]["pffConfiguration"], "policySet", v, p),
+    'rmt': lambda d, v, p: ps_set(d["rmtConfiguration"], "policySet", v, p),
+    'enrollment-task': lambda d, v, p: ps_set(d["enrollmentTaskConfiguration"], "policySet", v, p),
+    'flow-allocator': lambda d, v, p: ps_set(d["flowAllocatorConfiguration"], "policySet", v, p),
+    'namespace-manager': lambda d, v, p: ps_set(d["namespaceManagerConfiguration"], "policySet", v, p),
+    'security-manager': lambda d, v, p: ps_set(d["securityManagerConfiguration"], "policySet", v, p),
+    'routing': lambda d, v, p: ps_set(d["routingConfiguration"], "policySet", v, p),
+    'resource-allocator.pduftg': lambda d, v, p: ps_set(d["resourceAllocatorConfiguration"], "policySet", v, p),
     'efcp.*.dtcp': None,
     'efcp.*.dtp': None,
 }
 
-def translate_policy(difconf, path, ps):
+def translate_policy(difconf, path, ps, parms):
     if path in ['efcp.*.dtcp', 'efcp.*.dtp']:
-        for i in range(len(difconf["qosCubes"])):
-            if path =='efcp.*.dtcp':
-                difconf["qosCubes"][i]["efcpPolicies"]["dtcpConfiguration"]["dtcpPolicySet"]["name"] = ps
-            else:
-                difconf["qosCubes"][i]["efcpPolicies"]["dtpPolicySet"]["name"] = ps
+        if path =='efcp.*.dtcp':
+            dtcp_ps_set(difconf, ps, parms)
+        else:
+            dtp_ps_set(difconf, ps, parms)
     else:
-        policy_translator[path](difconf, ps)
+        policy_translator[path](difconf, ps, parms)
 


### PR DESCRIPTION
the policy declaration has been extended with an optional list of policy
parameters wiht the following syntax:

policy dif comp_path ps parm1=val1 parm2=val2 parm3=val3
