### PR TITLE
gen.py:Fix wrong gen_files_conf generation

### DIFF
--- a/gen.py
+++ b/gen.py
@@ -532,8 +532,9 @@ for vmname in sorted(vms):
 for vmname in sorted(vms):
     vm = vms[vmname]
 
-    gen_files_conf = 'shimeth.%(name)s.*.dif normal.%(name)s.*.dif da.map '\
-                     '%(name)s.ipcm.conf ' % {'name': vmname}
+    gen_files_conf = 'shimeth.%(name)s.*.dif da.map %(name)s.ipcm.conf ' % {'name': vmname}
+    if any(vmname in difd for difd in difs.values()):
+        gen_files_conf += 'normal.%(name)s.*.dif ' % {'name': vmname}
     gen_files_bin = 'enroll.py '
     overlay = ''
 


### PR DESCRIPTION
When a VM is declared in a shim DIF but not in a normal DIF the generation of
gen_files_conf fails because gen.py always adds to the list files in the form
of normal.%(name)s.*.dif. This makes the scp command failed and the up.sh gets
stuck in an infinite loop. This commits checks that the VM is part of the
normal DIF before adding the corresponding files.

On the other hand we can go for another option which checks if a shim is not used and fails. But, as a user, I found it useful to be able to have the shims there and go incrementally adding normal difs on top for different experiments.
