### PR TITLE
gen.py; fix bug introduced in 74a0868

### DIFF
--- a/gen.py
+++ b/gen.py
@@ -533,9 +533,9 @@ for vmname in sorted(vms):
 for vmname in sorted(vms):
     vm = vms[vmname]
 
-    gen_files_conf = 'shimeth.%(name)s.*.dif da.map %(name)s.ipcm.conf' % {'name': vmname}
+    gen_files_conf = 'shimeth.%(name)s.*.dif da.map %(name)s.ipcm.conf ' % {'name': vmname}
     if any(vmname in difs[difname] for difname in difs):
-        gen_files_conf += ' normal.%(name)s.*.dif ' % {'name': vmname}
+        gen_files_conf += 'normal.%(name)s.*.dif ' % {'name': vmname}
     gen_files_bin = 'enroll.py '
     overlay = ''
 


### PR DESCRIPTION
When generating gen_files_conf the line must always end with a blank space
