### PR TITLE
updated dc-vpns config file

### DIFF
--- a/examples/dc-vpns.conf
+++ b/examples/dc-vpns.conf
@@ -98,8 +98,8 @@ dif vpn4 tor4 45 46 47 48 dcfabric
 #Policies
 
 #Multipath FABRIC
-policy dcfabric * rmt.pff multipath
-policy dcfabric * routing link-state routingAlgorithm=ECMPDijkstra
+policy dcfabric spine1,spine2 rmt.pff multipath
+policy dcfabric spine1,spine2 routing link-state routingAlgorithm=ECMPDijkstra
 policy dcfabric * rmt cas-ps q_max=1000
 policy dcfabric * efcp.*.dtcp cas-ps
 


### PR DESCRIPTION
only use multipath policy in spines, not needed in ToRs