### PR TITLE
Allow full security configuration

### DIFF
--- a/examples/secure-two-layers.conf
+++ b/examples/secure-two-layers.conf
@@ -1,0 +1,25 @@
+eth 300 0Mbps a b
+eth 400 0Mbps b c
+eth 500 0Mbps c d
+
+# DIF n1 spans a,b and c and runs over the shims
+dif n1 a 300
+dif n1 b 300 400
+dif n1 c 400
+
+# DIF n2 spans c and d and runs over the shims
+dif n2 c 500
+dif n2 d 500
+
+# DIF n3 spans over n1 and n2
+dif n3 a n1
+dif n3 c n1 n2
+dif n3 d n2
+
+policy n3 * security-manager.auth.default PSOC_authentication-ssh2 keyExchangeAlg=EDH keystore=/creds keystorePass=test
+policy n3 * security-manager.encrypt.default default encryptAlg=AES128 macAlg=SHA256 compressAlg=deflate
+policy n3 * security-manager.ttl.default default initialValue=50
+policy n3 * security-manager.errorcheck.default CRC32
+policy n3 * security-manager.auth.n1 PSOC_authentication-password password=kf05j.a1234.af0k
+policy n3 * security-manager.ttl.n1 default initialValue=50
+policy n3 * security-manager.errorcheck.n1 CRC32

--- a/gen.py
+++ b/gen.py
@@ -297,7 +297,7 @@ while 1:
 
         continue
 
-    m = re.match(r'\s*policy\s+(\w+)\s+(\*|(?:(?:\w+,)*\w+))\s+([*\w.-]+)\s+([\w-]+)((?:\s+[\w.-]+\s*=\s*[\w.-]+)*)\s*$', line)
+    m = re.match(r'\s*policy\s+(\w+)\s+(\*|(?:(?:\w+,)*\w+))\s+([*\w.-]+)\s+([\w-]+)((?:\s+[\w.-]+\s*=\s*[/\w.-]+)*)\s*$', line)
     if m:
         dif = m.group(1)
         nodes = m.group(2)

--- a/gen.py
+++ b/gen.py
@@ -319,7 +319,7 @@ while 1:
 
         dif_policies[dif].append({'path': path, 'nodes': nodes,
                                   'ps': ps, 'parms' : parms})
-        if path not in gen_templates.policy_translator:
+        if not gen_templates.policy_path_valid(path):
             print('Unknown component path "%s"' % path)
             quit(1)
         continue

--- a/gen_templates.py
+++ b/gen_templates.py
@@ -263,11 +263,10 @@ def policy_path_valid(path):
     return path in policy_translator
 
 def translate_policy(difconf, path, ps, parms):
-    if path in ['efcp.*.dtcp', 'efcp.*.dtp']:
-        if path =='efcp.*.dtcp':
-            dtcp_ps_set(difconf, ps, parms)
-        else:
-            dtp_ps_set(difconf, ps, parms)
+    if path =='efcp.*.dtcp':
+        dtcp_ps_set(difconf, ps, parms)
+    elif path == 'efcp.*.dtp':
+        dtp_ps_set(difconf, ps, parms)
     else:
         policy_translator[path](difconf, ps, parms)
 

--- a/gen_templates.py
+++ b/gen_templates.py
@@ -222,7 +222,7 @@ normal_dif_base =  {
 
 def ps_set(d, k, v, parms):
     if k not in d:
-        d[k] = {'name': '', 'version': 1}
+        d[k] = {'name': '', 'version': '1'}
 
     if d[k]["name"] == v and "parameters" in d[k]:
         cur_names = [p["name"] for p in d[k]["parameters"]]

--- a/gen_templates.py
+++ b/gen_templates.py
@@ -278,7 +278,6 @@ def policy_path_valid(path):
 
     # Try to validate security configuration
     if is_security_path(path):
-            print('Validated security path "%s"' % (path,))
             return True
 
     return False

--- a/gen_templates.py
+++ b/gen_templates.py
@@ -219,7 +219,11 @@ normal_dif_base =  {
     }
 }
 
+
 def ps_set(d, k, v, parms):
+    if k not in d:
+        d[k] = {'name': '', 'version': 1}
+
     if d[k]["name"] == v and "parameters" in d[k]:
         cur_names = [p["name"] for p in d[k]["parameters"]]
         for p in parms:
@@ -237,13 +241,16 @@ def ps_set(d, k, v, parms):
 
     d[k]["name"] = v
 
+
 def dtp_ps_set(d, v, parms):
     for i in range(len(d["qosCubes"])):
         ps_set(d["qosCubes"][i]["efcpPolicies"], "dtpPolicySet", v, parms)
 
+
 def dtcp_ps_set(d, v, parms):
     for i in range(len(d["qosCubes"])):
         ps_set(d["qosCubes"][i]["efcpPolicies"]["dtcpConfiguration"], "dtcpPolicySet", v, parms)
+
 
 policy_translator = {
     'rmt.pff': lambda d, v, p: ps_set(d["rmtConfiguration"]["pffConfiguration"], "policySet", v, p),
@@ -258,15 +265,65 @@ policy_translator = {
     'efcp.*.dtp': None,
 }
 
+
+def is_security_path(path):
+    sp = path.split('.')
+    return (len(sp) == 3) and (sp[0] == 'security-manager') and (sp[1] in ['auth', 'encrypt', 'ttl', 'errorcheck'])
+
+
 # Do we know this path ?
 def policy_path_valid(path):
-    return path in policy_translator
+    if path in policy_translator:
+        return True
+
+    # Try to validate security configuration
+    if is_security_path(path):
+            print('Validated security path "%s"' % (path,))
+            return True
+
+    return False
+
+
+def translate_security_path(d, path, ps, parms):
+    u1, component, profile = path.split('.')
+    if "authSDUProtProfiles" not in d["securityManagerConfiguration"]:
+        d["securityManagerConfiguration"]["authSDUProtProfiles"] = {}
+    d = d["securityManagerConfiguration"]["authSDUProtProfiles"]
+
+    tr = {'auth': 'authPolicy', 'encrypt': 'encryptPolicy',
+          'ttl': 'TTLPolicy', 'errorcheck': 'ErrorCheckPolicy'}
+
+    if profile == 'default':
+        if profile not in d:
+            d["default"] = {}
+
+        ps_set(d["default"], tr[component], ps, parms)
+
+    else: # profile is the name of a DIF
+        if "specific" not in d:
+            d["specific"] = []
+        j = -1
+        for i in range(len(d["specific"])):
+            if d["specific"][i]["underlyingDIF"] == profile + ".DIF":
+                j = i
+                break
+
+        if j == -1: # We need to create an entry for the new DIF
+            d["specific"].append({"underlyingDIF" : profile + ".DIF"})
+
+        ps_set(d["specific"][j], tr[component], ps, parms)
+
 
 def translate_policy(difconf, path, ps, parms):
     if path =='efcp.*.dtcp':
         dtcp_ps_set(difconf, ps, parms)
+
     elif path == 'efcp.*.dtp':
         dtp_ps_set(difconf, ps, parms)
+
+    elif is_security_path(path):
+        translate_security_path(difconf, path, ps, parms)
+
     else:
         policy_translator[path](difconf, ps, parms)
 

--- a/gen_templates.py
+++ b/gen_templates.py
@@ -258,6 +258,10 @@ policy_translator = {
     'efcp.*.dtp': None,
 }
 
+# Do we know this path ?
+def policy_path_valid(path):
+    return path in policy_translator
+
 def translate_policy(difconf, path, ps, parms):
     if path in ['efcp.*.dtcp', 'efcp.*.dtp']:
         if path =='efcp.*.dtcp':


### PR DESCRIPTION
This patch addresses #28 , to allow full security configuration to be expressed by the demonstrator configuration file, by means of the policy directive.

Example of a demonstrator configuration file with full security configuration is at `examples/secure-two-layers.conf`.