### PR TITLE
Apply patch to get rate limiting of eth interfaces back to work

### DIFF
--- a/gen.py
+++ b/gen.py
@@ -617,13 +617,15 @@ for l in sorted(links):
 
     if shims[shim]['speed'] > 0:
         speed = '%d%sbit' % (shims[shim]['speed'], shims[shim]['speed_unit'])
-        if shim not in netems:
-            netems[shim] = dict()
-        if vm not in netems[shim]:
-            netems[shim][vm] = {'args': '', 'linecnt': 0}
 
         # Rate limit the traffic transmitted on the TAP interface
-        netems[shim][vm]['args'] += ' rate %s' % (speed,)
+        outs += 'sudo tc qdisc add dev %(tap)s handle 1: root '     \
+                                'htb default 11\n'                  \
+                'sudo tc class add dev %(tap)s parent 1: classid '  \
+                                '1:1 htb rate 10gbit\n'             \
+                'sudo tc class add dev %(tap)s parent 1:1 classid ' \
+                                '1:11 htb rate %(speed)s\n'         \
+                % {'tap': tap, 'speed': speed}
 
     if shim in netems:
         if vm in netems[shim]:


### PR DESCRIPTION
Support for rate limiting in the "eth" directive is broken because we switched to netem. Apparently, the netem commands used to implement rate limiting are wrong. We can just revert to the previous HTB based implementation.
Please, @vmaffione could you merge?